### PR TITLE
Error refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Level 3 issues *MUST* be completed before the release of this library. These iss
 |-------|-------|--------- |
 | 3     | `pixmap_image_open()` does not yet parse the pixel information into the `_pixels` array | No |
 | 2     | `pixmap_image_get_pixel()` currently returns a pointer to an `RGB` that corresponds to the pixel in the image. If the user changes any of the members in the `RGB` variable and calls `pixmap_image_save()` the pixel will change to one the user provided. It would better only to have the pixels changed through the `pixmap_image_set_pixel()` function. | No |
-| 1     | Some functions like `pixmap_image_set_pixel()` doesn't tell the user if an error occurred. This should be rectified eventually. | No |
+| 1     | An inconsistent error mechanism exists in the library. Some functions return 0 to signify an error happened. Other functions that have void as a return type like `pixmap_image_set_pixel()` simply do nothing if a condition was not met or an error occurred. How does the user know if something went awry? They can't and this problem should be fixed eventually. | No |
 
 ## Build
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Level 3 issues *MUST* be completed before the release of this library. These iss
 |-------|-------|--------- |
 | 3     | `pixmap_image_open()` does not yet parse the pixel information into the `_pixels` array | No |
 | 2     | `pixmap_image_get_pixel()` currently returns a pointer to an `RGB` that corresponds to the pixel in the image. If the user changes any of the members in the `RGB` variable and calls `pixmap_image_save()` the pixel will change to one the user provided. It would better only to have the pixels changed through the `pixmap_image_set_pixel()` function. | No |
-| 1     | An inconsistent error mechanism exists in the library. Some functions return 0 to signify an error happened. Other functions that have void as a return type like `pixmap_image_set_pixel()` simply do nothing if a condition was not met or an error occurred. How does the user know if something went awry? They can't and this problem should be fixed eventually. | No |
+| 1     | Some functions like `pixmap_image_set_pixel()` doesn't tell the user if an error occurred. This should be rectified eventually. | No |
 
 ## Build
 

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -94,9 +94,13 @@ PixMapImage *pixmap_image_open(char const *name)
     return new_image;
 }
 
-void pixmap_image_set_pixel(PixMapImage *image, unsigned int x, unsigned int y, unsigned int red, unsigned int green, unsigned int blue)
+void pixmap_image_set_pixel(PixMapImage *image, unsigned int x, unsigned int y, unsigned int red, unsigned int green, unsigned int blue, int *error)
 {
-    if(x > (image->_width - 1) || y > (image->_height - 1)) return;
+    if(x > (image->_width - 1) || y > (image->_height - 1))
+    {
+        if(error) *error = 1;
+        return;
+    }
 
     red = red <= 255 ? red : 255;
     green = green <= 255 ? green : 255;

--- a/src/pixmap.h
+++ b/src/pixmap.h
@@ -18,7 +18,8 @@ PixMapImage *pixmap_image_new                (char const *name, int width, int h
 PixMapImage *pixmap_image_open               (char const *name);
 void         pixmap_image_set_pixel          (PixMapImage *image,
                                               unsigned int x, unsigned int y,
-                                              unsigned int red, unsigned int green, unsigned int blue);
+                                              unsigned int red, unsigned int green, unsigned int blue,
+                                              int *error);
 RGB         *pixmap_image_get_pixel          (PixMapImage *image, unsigned int x, unsigned int y);
 void         pixmap_image_save               (PixMapImage *image);
 int          pixmap_image_get_width          (PixMapImage *image);


### PR DESCRIPTION
When I first begun this refactoring I thought there should be a more consistent error reporting mechanism. Now that I have thought it over I think the best course of action is to allow the functions that already return a pointer return 0 on failure and other functions that return non-pointer values return a designated value that signifies that an error happened.

If a function that returns nothing like `pixmap_image_set_pixel()` will have an extra argument that points to an integer and if that integer is 1 then an error has happened.