### PR TITLE
pixmap_image_open: moved the test for invalid filename or missing fil…

### DIFF
--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -34,10 +34,9 @@ PixMapImage *pixmap_image_new(char const *name, int width, int height, int max_c
 
 PixMapImage *pixmap_image_open(char const *name)
 {
-    FILE *image_file = fopen(new_image->_file_name, "r+");
+    FILE *image_file = fopen(name, "r+");
     if(!image_file)
     {
-        free(new_image);
         return 0;
     }
 

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -115,39 +115,40 @@ PixMapImage *pixmap_image_open(char const *name)
     }
 
     RGB pixel;
-    unsigned int a = 0;
-    int b = 1;
-    int pos = 0;
-
+    unsigned int value_in = 0;
+    int rgb_counter = 1;
+    int file_pos = 0;
+    
+    /* Read in the pixel values */
     while((c = fgetc(image_file)) != EOF)
     {
-        a = 0;
+        value_in = 0;
         if(isdigit(c))
         {
             ungetc(c, image_file);
-            if(b > 3)
+            if(rgb_counter > 3)
             {
-                new_image->_pixels[pos] = pixel;
-                pos++;
-                b = 1;
+                new_image->_pixels[file_pos] = pixel;
+                file_pos++;
+                rgb_counter = 1;
             }
             
             while((c = fgetc(image_file)) != EOF && c != ' ')
             {
-                a *= 10;
-                a += (c - '0');
+                value_in *= 10;
+                value_in += (c - '0');
             }
 
-            printf("COLOR: %u\n", a);
+            printf("COLOR: %u\n", value_in);
 
-            if(b == 1)
-                pixel.red = a;
-            else if(b == 2)
-                pixel.green = a;
-            else if(b == 3)
-                pixel.blue = a;
+            if(rgb_counter == 1)
+                pixel.red = value_in;
+            else if(rgb_counter == 2)
+                pixel.green = value_in;
+            else if(rgb_counter == 3)
+                pixel.blue = value_in;
             
-            b++;
+            rgb_counter++;
         }
     }
 

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -34,19 +34,18 @@ PixMapImage *pixmap_image_new(char const *name, int width, int height, int max_c
 
 PixMapImage *pixmap_image_open(char const *name)
 {
-    PixMapImage *new_image = malloc(sizeof(*new_image));
-
-    if(!new_image) return 0;
-
-    new_image->_file_name = name;
-
     FILE *image_file = fopen(new_image->_file_name, "r+");
-
     if(!image_file)
     {
         free(new_image);
         return 0;
     }
+
+    PixMapImage *new_image = malloc(sizeof(*new_image));
+
+    if(!new_image) return 0;
+
+    new_image->_file_name = name;
 
     unsigned char sig[3];
     fread(sig, sizeof(unsigned char), 2, image_file);


### PR DESCRIPTION
…e to before memory is allocated

If the filename is invalid, it should return error before allocating memory.