### PR TITLE
removed signedness comparison mismatches

### DIFF
--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -178,9 +178,10 @@ RGB *pixmap_image_get_pixel_array(PixMapImage *image)
     return image->_pixels;
 }
 
-void pixmap_image_set_pixel(PixMapImage *image, unsigned int x, unsigned int y, unsigned int red, unsigned int green, unsigned int blue, int *error)
+void pixmap_image_set_pixel(PixMapImage *image, int x, int y, int red, int green, int blue, int *error)
 {
-    if(x > (image->_width - 1) || y > (image->_height - 1))
+    if(x > (image->_width - 1) || y > (image->_height - 1)
+       || x < 0 || y < 0 || red < 0 || green < 0 || blue < 0)
     {
         if(error) *error = 1;
         return;
@@ -196,9 +197,10 @@ void pixmap_image_set_pixel(PixMapImage *image, unsigned int x, unsigned int y, 
     image->_pixels[x + (y * image->_width)] = color;
 }
 
-RGB pixmap_image_get_pixel(PixMapImage *image, unsigned int x, unsigned int y)
+RGB pixmap_image_get_pixel(PixMapImage *image, int x, int y)
 {
-    if(x > (image->_width - 1) || y > (image->_height - 1))
+    if(x > (image->_width - 1) || y > (image->_height - 1)
+       || x < 0 || y < 0)
     {
         RGB error_pixel = {-1, -1, -1};
         return error_pixel;

--- a/src/pixmap.h
+++ b/src/pixmap.h
@@ -17,12 +17,12 @@ typedef struct _RGB
 PixMapImage *pixmap_image_new                (char const *name, int width, int height, int max_color_val);
 PixMapImage *pixmap_image_open               (char const *name);
 PixMapImage *pixmap_image_copy               (PixMapImage *image, char const *new_name);
-RGB         *pixmap_image_get_pixel_array    (PixmapImage *image);
+RGB         *pixmap_image_get_pixel_array    (PixMapImage *image);
 void         pixmap_image_set_pixel          (PixMapImage *image,
-                                              unsigned int x, unsigned int y,
-                                              unsigned int red, unsigned int green, unsigned int blue,
+                                              int x, int y,
+                                              int red, int green, int blue,
                                               int *error);
-RGB          pixmap_image_get_pixel          (PixMapImage *image, unsigned int x, unsigned int y);
+RGB          pixmap_image_get_pixel          (PixMapImage *image, int x, int y);
 int          pixmap_image_save               (PixMapImage *image);
 int          pixmap_image_get_width          (PixMapImage *image);
 int          pixmap_image_get_height         (PixMapImage *image);


### PR DESCRIPTION
The _PixMapImage and RGB structs all use signed ints, but pixmap_image_set_pixel and pixmap_image_get_pixel take unsigned ints. Leaving the structs with signed ints allows for a convenient error value. Certain machines may give erroneous results if a signed int and unsigned int are compared.