### PR TITLE
Make endian agnostic

### DIFF
--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -247,7 +247,10 @@ void pixmap_image_close(PixMapImage *image)
 {
     if(!image) return;
 
-    free(image->_pixels);
+    if(image->_pixels) {
+      free(image->_pixels);
+      image->_pixels = NULL;
+    }
     free(image);
 }
 

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -119,7 +119,14 @@ PixMapImage *pixmap_image_open(char const *name)
 		    }
 	    }
     } else if(sig[1] == '6') {
-	/* TODO write binary read loop*/
+	int total_pixels = width * height;
+	unsigned char value_in[3];
+	for(int i = 0; i < total_pixels; i++) {
+	    fread(value_in, sizeof(unsigned char), 3, image_file);
+	    new_image->_pixels[i] = (RGB) {.red = ntohs(value_in[0]),
+					   .green = ntohs(value_in[1]),
+					   .blue = ntohs(value_in[2])};
+	}
     } else {
 	fclose(image_file);
 	free(new_image);

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -312,7 +312,7 @@ static void read_ascii_pixel_values(PixMapImage *image, FILE *image_file)
     }
     if(file_pos > total_pixels) {
 	free(image);
-	image = NULL
+	image = NULL;
 	fclose(image_file);
 	return;
     }
@@ -320,11 +320,11 @@ static void read_ascii_pixel_values(PixMapImage *image, FILE *image_file)
 
 static void read_binary_pixel_values(PixMapImage *image, FILE *image_file)
 {
-    int total_pixels = width * height;
+    int total_pixels = image->_width * image->_height;
     unsigned char value_in[3];
     for(int i = 0; i < total_pixels; i++) {
-	fread(value_in, sizeof(unsigned char), 3, image_file);
-	if(!value_in) {
+	if(fread(value_in, sizeof(unsigned char), 3, image_file)
+	   != sizeof(unsigned char) * 3) {
 	    fprintf(stderr, "ERROR invalid image file\n");
 	    fclose(image_file);
 	    free(image);
@@ -335,3 +335,4 @@ static void read_binary_pixel_values(PixMapImage *image, FILE *image_file)
 				       .green = ntohs(value_in[1]),
 				       .blue = ntohs(value_in[2])};
     }
+}

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -204,8 +204,8 @@ int pixmap_image_save(PixMapImage *image)
             for(int x = 0; x < image->_width; x++)
             {
                 temp_pixels[x + (y * image->_width)] = (uint8_t) htons(image->_pixels[x + (y * image->_width)].red);
-                temp_pixels[(x + (y * image->_width) + 1)] = (uint8_t) htons(image->_pixels[x + (y * image->_width)].green);
-                temp_pixels[(x + (y * image->_width) + 2)] = (uint8_t) htons(image->_pixels[x + (y * image->_width)].blue);
+                temp_pixels[(x + (y * image->_width) + sizeof(uint8_t))] = (uint8_t) htons(image->_pixels[x + (y * image->_width)].green);
+                temp_pixels[(x + (y * image->_width) + (sizeof(uint8_t) * 2))] = (uint8_t) htons(image->_pixels[x + (y * image->_width)].blue);
             }
         }
 
@@ -324,9 +324,9 @@ static void read_ascii_pixel_values(PixMapImage *image, FILE *image_file)
 static void read_binary_pixel_values(PixMapImage *image, FILE *image_file)
 {
     int total_pixels = image->_width * image->_height;
-    unsigned char value_in[3];
+    uint8_t value_in[3];
     for(int i = 0; i < total_pixels; i++) {
-	if(fread(value_in, sizeof(unsigned char), 3, image_file)
+	if(fread(value_in, sizeof(uint8_t), 3, image_file)
 	   != sizeof(uint8_t) * 3) {
 	    fclose(image_file);
 	    free(image);

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -112,7 +112,7 @@ PixMapImage *pixmap_image_copy(PixMapImage *image, char const *new_name, PixMapI
     int i = 0;
     while(i < copy_image->_width * copy_image->_height)
     {
-        copy_image->_pixels[i] = image->_pixels[i];
+	copy_image->_pixels[i] = image->_pixels[i];
         i++;
     }
 
@@ -191,7 +191,7 @@ int pixmap_image_save(PixMapImage *image)
         }
     } else if(image->_type == Binary)
     {
-        unsigned char *temp_pixels = malloc(sizeof(unsigned char) * image->_width * image->_height * 3);
+        uint8_t *temp_pixels = malloc(sizeof(uint8_t) * image->_width * image->_height * 3);
         
         if(!temp_pixels)
         {
@@ -203,14 +203,14 @@ int pixmap_image_save(PixMapImage *image)
         {
             for(int x = 0; x < image->_width; x++)
             {
-                temp_pixels[x + (y * image->_width)] = htons(image->_pixels[x + (y * image->_width)].red);
-                temp_pixels[(x + (y * image->_width) + 1)] = htons(image->_pixels[x + (y * image->_width)].green);
-                temp_pixels[(x + (y * image->_width) + 2)] = htons(image->_pixels[x + (y * image->_width)].blue);
+                temp_pixels[x + (y * image->_width)] = (uint8_t) htons(image->_pixels[x + (y * image->_width)].red);
+                temp_pixels[(x + (y * image->_width) + 1)] = (uint8_t) htons(image->_pixels[x + (y * image->_width)].green);
+                temp_pixels[(x + (y * image->_width) + 2)] = (uint8_t) htons(image->_pixels[x + (y * image->_width)].blue);
             }
         }
 
         fprintf(image_file, "%s\n%d %d\n%d\n", "P6", image->_width, image->_height, image->_max_color_value);
-        fwrite(temp_pixels, sizeof(unsigned char), image->_width * image->_height, image_file);
+        fwrite(temp_pixels, sizeof(uint8_t), image->_width * image->_height, image_file);
 
         free(temp_pixels);
     }
@@ -324,7 +324,7 @@ static void read_binary_pixel_values(PixMapImage *image, FILE *image_file)
     unsigned char value_in[3];
     for(int i = 0; i < total_pixels; i++) {
 	if(fread(value_in, sizeof(unsigned char), 3, image_file)
-	   != sizeof(unsigned char) * 3) {
+	   != sizeof(uint8_t) * 3) {
 	    fclose(image_file);
 	    free(image);
 	    image = NULL;

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -325,7 +325,6 @@ static void read_binary_pixel_values(PixMapImage *image, FILE *image_file)
     for(int i = 0; i < total_pixels; i++) {
 	if(fread(value_in, sizeof(unsigned char), 3, image_file)
 	   != sizeof(unsigned char) * 3) {
-	    fprintf(stderr, "ERROR invalid image file\n");
 	    fclose(image_file);
 	    free(image);
 	    image = NULL;

--- a/src/pixmap.h
+++ b/src/pixmap.h
@@ -4,6 +4,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <stdint.h>		/* uint8_t */
 #include <arpa/inet.h>		/* htons, ntohs (Linux only)
 				   maybe add conditional compilation
 				   for other platforms */

--- a/src/pixmap.h
+++ b/src/pixmap.h
@@ -4,6 +4,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
+#include <arpa/inet.h>		/* htons, ntohs (Linux only)
+				   maybe add conditional compilation
+				   for other platforms */
 
 typedef struct _PixMapImage PixMapImage;
 

--- a/test/main.c
+++ b/test/main.c
@@ -52,13 +52,15 @@ int test2()
 
     if(status != 0)
         return -1;
-    
+
+    pixmap_image_close(image_in);
+    pixmap_image_close(image_out);
     return 0;
 }
 
 int test3()
 {
-    PixMapImage *image = pixmap_image_new("test2.ppm", 100, 100, 255, Binary);
+    PixMapImage *image = pixmap_image_new("test_binary.ppm", 100, 100, 255, Binary);
 
     if(!image)
         return -1;
@@ -67,12 +69,32 @@ int test3()
     {
         for(int x = 0; x < pixmap_image_get_width(image); x++)
         {
-            pixmap_image_set_pixel(image, y, x, 255, 0, 0, 0);
+            pixmap_image_set_pixel(image, y, x, 255, y, x, NULL);
         }
     }
 
     pixmap_image_save(image);
 
+    pixmap_image_close(image);
+    return 0;
+}
+
+int test4(void)
+{
+    PixMapImage *image = pixmap_image_open("test_binary.ppm");
+    if(!image)
+	return -1;
+
+    PixMapImage *image_out = pixmap_image_copy(image, "test_binary2.ppm", Binary);
+    if(!image_out) {
+	return -1;
+    }
+
+    if(pixmap_image_save(image_out) != 0)
+	return -1;
+
+    pixmap_image_close(image);
+    pixmap_image_close(image_out);
     return 0;
 }
 
@@ -86,6 +108,9 @@ int main()
     
     if(test3() != 0)
         return -1;
+
+    if(test4() != 0)
+	return -1;
     
     return 0;
 }


### PR DESCRIPTION
This uses ntohs() and htons() to make opening binary files endian-agnostic. The header for Linux to get ntohs() and htons() is <arpa/inet.h>. There are versions of ntohs() and htons() for Windows and Mac OSX, but I don't know what those headers are and I don't have access to them. It also adds some error checking to the pixel read loops and factors them into their own functions to keep any one function from getting too long.