### PR TITLE
Add component split

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 .vscode
+*~

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 build
 .vscode
+
+# Emacs temporary file
 *~

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -179,6 +179,9 @@ RGB pixmap_image_get_pixel(PixMapImage *image, int x, int y)
 
 int pixmap_image_save(PixMapImage *image)
 {
+    if(!image->_file_name)
+	return -1;
+
     FILE *image_file = fopen(image->_file_name, "w");
 
     if(!image_file)

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -147,8 +147,8 @@ void pixmap_image_set_pixel(PixMapImage *image, int x, int y, int red, int green
     if(x > (image->_width - 1) || y > (image->_height - 1)
        || x < 0 || y < 0 || red < 0 || green < 0 || blue < 0)
     {
-        if(error) *error = 1;
-        return;
+	*error = 1;
+	return;
     }
 
     red = red <= image->_max_color_value ? red : image->_max_color_value;
@@ -156,9 +156,6 @@ void pixmap_image_set_pixel(PixMapImage *image, int x, int y, int red, int green
     blue = blue <= image->_max_color_value ? blue : image->_max_color_value;
 
     RGB color = { red, green, blue };
-
-    if(error)
-        *error = 0;
 
     image->_pixels[x + (y * image->_width)] = color;
 }
@@ -212,6 +209,11 @@ int pixmap_image_get_height(PixMapImage *image)
 int pixmap_image_get_max_color_value(PixMapImage *image)
 {
     return image->_max_color_value;
+}
+
+PixMapImageType pixmap_image_get_type (PixMapImage *image)
+{
+    return image->_type;
 }
 
 void pixmap_image_foreach_pixel(PixMapImage *image,

--- a/src/pixmap.h
+++ b/src/pixmap.h
@@ -39,6 +39,7 @@ int          pixmap_image_save               (PixMapImage *image);
 int          pixmap_image_get_width          (PixMapImage *image);
 int          pixmap_image_get_height         (PixMapImage *image);
 int          pixmap_image_get_max_color_value(PixMapImage *image);
+PixMapImageType pixmap_image_get_type        (PixMapImage *image);
 void         pixmap_image_foreach_pixel      (PixMapImage *image,
 					      void (*func)(RGB pixel, void *func_arg),
 					      void * arg);

--- a/src/pixmap_filters.c
+++ b/src/pixmap_filters.c
@@ -47,10 +47,9 @@ PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image)
     res->blue = pixmap_image_new(NULL, width, height, max_value, type);
 
     if(!res->red || !res->green || !res->blue)
-      return NULL
+      return NULL;
 
-    int *error = malloc(sizeof(int));
-    *error = 0;
+    int error = 0;
     for(int y = 0; y < height; y++)
     {
 	for(int x = 0; x < width; x++)
@@ -60,7 +59,7 @@ PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image)
 	    pixmap_image_set_pixel(res->green, x, y, 0, pixel.green, 0, error);
 	    pixmap_image_set_pixel(res->blue, x, y, 0, 0, pixel.blue, error);
 
-	    if(*error)
+	    if(error)
 	    {
 		pixmap_image_close(res->red);
 		pixmap_image_close(res->green);
@@ -69,7 +68,6 @@ PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image)
 	    }
 	}
     }
-    free(error);
     return res;
 }
 

--- a/src/pixmap_filters.c
+++ b/src/pixmap_filters.c
@@ -72,3 +72,12 @@ PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image)
     free(error);
     return res;
 }
+
+void pixmap_filter_close_components(PixMapComponents *components)
+{
+    pixmap_image_close(components->red);
+    pixmap_image_close(components->green);
+    pixmap_image_close(components->blue);
+
+    free(components);
+}

--- a/src/pixmap_filters.c
+++ b/src/pixmap_filters.c
@@ -61,8 +61,14 @@ PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image)
 	    pixmap_image_set_pixel(res->blue, x, y, 0, 0, pixel.blue, error);
 
 	    if(*error)
+	    {
+		pixmap_image_close(res->red);
+		pixmap_image_close(res->green);
+		pixmap_image_close(res->blue);
 		return NULL;
+	    }
 	}
     }
+    free(error);
     return res;
 }

--- a/src/pixmap_filters.c
+++ b/src/pixmap_filters.c
@@ -29,3 +29,37 @@ void pixmap_filter_brightness(PixMapImage *image, int brightness, int *error)
 	}
     }
 }
+
+PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image)
+{
+    int width = pixmap_image_get_width(image);
+    int height = pixmap_image_get_height(image);
+    int max_value = pixmap_image_get_max_color_value(image);
+    PixMapImageType type = pixmap_image_get_type(image);
+    
+    PixMapComponents *res = malloc(sizeof(PixMapComponents));
+    if(!res)
+    {
+	return NULL;
+    }
+
+    res->red = pixmap_image_new(NULL, width, height, max_value, type);
+    res->green = pixmap_image_new(NULL, width, height, max_value, type);
+    res->blue = pixmap_image_new(NULL, width, height, max_value, type);
+
+    int *error = malloc(sizeof(int));
+    *error = 0;
+    for(int y = 0; y < height; y++)
+    {
+	for(int x = 0; x < width; x++)
+	{
+	    RGB pixel = pixmap_image_get_pixel(image, x, y);
+	    pixmap_image_set_pixel(res->red, x, y, pixel.red, 0, 0, error);
+	    pixmap_image_set_pixel(res->green, x, y, 0, pixel.green, 0, error);
+	    pixmap_image_set_pixel(res->blue, x, y, 0, 0, pixel.blue, error);
+	    if(*error)
+		return NULL;
+	}
+    }
+    return res;
+}

--- a/src/pixmap_filters.c
+++ b/src/pixmap_filters.c
@@ -38,14 +38,16 @@ PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image)
     PixMapImageType type = pixmap_image_get_type(image);
     
     PixMapComponents *res = malloc(sizeof(PixMapComponents));
+
     if(!res)
-    {
 	return NULL;
-    }
 
     res->red = pixmap_image_new(NULL, width, height, max_value, type);
     res->green = pixmap_image_new(NULL, width, height, max_value, type);
     res->blue = pixmap_image_new(NULL, width, height, max_value, type);
+
+    if(!res->red || !res->green || !res->blue)
+      return NULL
 
     int *error = malloc(sizeof(int));
     *error = 0;
@@ -57,6 +59,7 @@ PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image)
 	    pixmap_image_set_pixel(res->red, x, y, pixel.red, 0, 0, error);
 	    pixmap_image_set_pixel(res->green, x, y, 0, pixel.green, 0, error);
 	    pixmap_image_set_pixel(res->blue, x, y, 0, 0, pixel.blue, error);
+
 	    if(*error)
 		return NULL;
 	}

--- a/src/pixmap_filters.c
+++ b/src/pixmap_filters.c
@@ -55,9 +55,9 @@ PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image)
 	for(int x = 0; x < width; x++)
 	{
 	    RGB pixel = pixmap_image_get_pixel(image, x, y);
-	    pixmap_image_set_pixel(res->red, x, y, pixel.red, 0, 0, error);
-	    pixmap_image_set_pixel(res->green, x, y, 0, pixel.green, 0, error);
-	    pixmap_image_set_pixel(res->blue, x, y, 0, 0, pixel.blue, error);
+	    pixmap_image_set_pixel(res->red, x, y, pixel.red, 0, 0, &error);
+	    pixmap_image_set_pixel(res->green, x, y, 0, pixel.green, 0, &error);
+	    pixmap_image_set_pixel(res->blue, x, y, 0, 0, pixel.blue, &error);
 
 	    if(error)
 	    {

--- a/src/pixmap_filters.h
+++ b/src/pixmap_filters.h
@@ -10,3 +10,4 @@ typedef struct _PixMapComponents {
 
 void pixmap_filter_brightness(PixMapImage *image, int brighness, int *error);
 PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image);
+void pixmap_filter_close_components(PixMapComponents *components);

--- a/src/pixmap_filters.h
+++ b/src/pixmap_filters.h
@@ -2,4 +2,11 @@
 
 #include "pixmap.h"
 
+typedef struct _PixMapComponents {
+    PixMapImage *red;
+    PixMapImage *green;
+    PixMapImage *blue;
+} PixMapComponents;
+
 void pixmap_filter_brightness(PixMapImage *image, int brighness, int *error);
+PixMapComponents *pixmap_filter_split_into_components(PixMapImage *image);


### PR DESCRIPTION
Adds a function to create three images for red, blue, and green channels. `struct PixMapComponents` is a way to return the three `PixMapImage`s using one function.

Users will have to copy their individual `PixMapImage`s into separate objects to save them properly.