### PR TITLE
Add greyscale support

### DIFF
--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -13,14 +13,19 @@ struct _PixMapImage
 static int get_metadata_value(FILE *file);
 static int read_ascii_pixel_values_rgb(PixMapImage *image, FILE *image_file);
 static int read_8_bit_binary_pixel_values_rgb(PixMapImage *image, FILE *image_file);
-static int read_16_bit_binary_pixel_values_rgb(PixMapImage *image,
-                                           FILE *image_file);
+static int read_16_bit_binary_pixel_values_rgb(PixMapImage *image, FILE *image_file);
+
+static int read_ascii_pixel_values_greyscale(PixMapImage *image, FILE *image_file);
+static int read_8_bit_binary_pixel_values_greyscale(PixMapImage *image, FILE *image_file);
+static int read_16_bit_binary_pixel_values_greyscale(PixMapImage *image, FILE *image_file);
+
 static int write_ascii_file_rgb(PixMapImage const *image, FILE *image_file);
 static int write_8_bit_binary_file_rgb(PixMapImage const *image, FILE *image_file);
 static int write_16_bit_binary_file_rgb(PixMapImage const *image, FILE *image_file);
 
 static int write_ascii_file_greyscale(PixMapImage const *image, FILE *image_file);
 static int write_8_bit_binary_file_greyscale(PixMapImage const *image, FILE *image_file);
+static int write_16_bit_binary_file_greyscale(PixMapImage const *image, FILE *image_file);
 
 PixMapImage *pixmap_image_new(char const *name, int width, int height,
                               int max_color_val, PixMapImageType type)
@@ -95,17 +100,35 @@ PixMapImage *pixmap_image_open(char const *name)
         return 0;
     }
 
-    if(sig[1] == '3')
+    if(sig[1] == '2')
     {
-        if(read_ascii_pixel_values_rgb(new_image, image_file) < 0) return 0;
+	if(read_ascii_pixel_values_greyscale(new_image, image_file) < 0)
+	    return 0;
+    }	   
+    else if(sig[1] == '3')
+    {
+        if(read_ascii_pixel_values_rgb(new_image, image_file) < 0)
+	    return 0;
+    }
+    else if(sig[1] == '4' && new_image->_max_color_value <= 255)
+    {
+	if(read_8_bit_binary_pixel_values_greyscale(new_image, image_file) < 0)
+	    return 0;
+    }
+    else if(sig[1] == '4' && new_image->_max_color_value > 255)
+    {
+	if(read_16_bit_binary_pixel_values_greyscale(new_image, image_file) < 0)
+	    return 0;
     }
     else if(sig[1] == '6' && new_image->_max_color_value <= 255)
     {
-        if(read_8_bit_binary_pixel_values_rgb(new_image, image_file) < 0) return 0;
+        if(read_8_bit_binary_pixel_values_rgb(new_image, image_file) < 0)
+	    return 0;
     }
     else if(sig[1] == '6' && new_image->_max_color_value > 255)
     {
-        if(read_16_bit_binary_pixel_values_rgb(new_image, image_file) < 0) return 0;
+        if(read_16_bit_binary_pixel_values_rgb(new_image, image_file) < 0)
+	    return 0;
     }
     else
     {
@@ -367,6 +390,87 @@ static int read_16_bit_binary_pixel_values_rgb(PixMapImage *image, FILE *image_f
 
     return 0;
 }
+
+static int read_ascii_pixel_values_greyscale(PixMapImage *image, FILE *image_file)
+{
+    int c;
+    unsigned int value_in = 0;
+    int file_pos = 0;
+    int total_pixels = image->_width * image->_height;
+
+    /* Read in the pixel values */
+    while((c = fgetc(image_file)) != EOF)
+    {
+        value_in = 0;
+        if(isdigit(c))
+        {
+            ungetc(c, image_file);
+            while((c = fgetc(image_file)) != EOF && c != ' ' && c != '\n')
+            {
+                value_in *= 10;
+                value_in += (c - '0');
+            }
+	    image->_pixels[file_pos] = (RGB) {.red = value_in,
+				       .green = value_in,
+				       .blue = value_in};
+	    file_pos++;
+        }
+    }
+
+    if(file_pos > total_pixels)
+    {
+        free(image);
+        image = NULL;
+        fclose(image_file);
+
+        return -1;
+    }
+
+    return 0;
+}
+
+static int read_8_bit_binary_pixel_values_greyscale(PixMapImage *image, FILE *image_file)
+{
+    uint8_t value_in = 0;
+    int total_pixels = image->_width * image->_height;
+    
+    for(int i = 0; i < total_pixels; i++)
+    {
+	fread(&value_in, sizeof(uint8_t), 1, image_file);
+	if(ferror(image_file))
+	{
+	    fclose(image_file);
+	    pixmap_image_close(image);
+	    return -1;
+	}
+	image->_pixels[i] = (RGB) {.red = value_in,
+				   .green = value_in,
+				   .blue = value_in};
+    }
+    return 0;
+}
+
+static int read_16_bit_binary_pixel_values_greyscale(PixMapImage *image, FILE *image_file)
+{
+    uint16_t value_in = 0;
+    int total_pixels = image->_width * image->_height;
+    
+    for(int i = 0; i < total_pixels; i++)
+    {
+	fread(&value_in, sizeof(uint16_t), 1, image_file);
+	if(ferror(image_file))
+	{
+	    fclose(image_file);
+	    pixmap_image_close(image);
+	    return -1;
+	}
+	image->_pixels[i] = (RGB) {.red = value_in,
+				   .green = value_in,
+				   .blue = value_in};
+    }
+    return 0;
+}
+	
 
 static int write_ascii_file_rgb(PixMapImage const *image, FILE *image_file)
 {

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -15,9 +15,11 @@ static int read_ascii_pixel_values(PixMapImage *image, FILE *image_file);
 static int read_8_bit_binary_pixel_values(PixMapImage *image, FILE *image_file);
 static int read_16_bit_binary_pixel_values(PixMapImage *image,
                                            FILE *image_file);
-static int write_ascii_file(PixMapImage *image, FILE *image_file);
-static int write_8_bit_binary_file(PixMapImage *image, FILE *image_file);
-static int write_16_bit_binary_file(PixMapImage *image, FILE *image_file);
+static int write_ascii_file_rgb(PixMapImage *image, FILE *image_file);
+static int write_8_bit_binary_file_rgb(PixMapImage *image, FILE *image_file);
+static int write_16_bit_binary_file_rgb(PixMapImage *image, FILE *image_file);
+
+static int write_ascii_file_greyscale(PixMapImage *image, FILE *image_file);
 
 PixMapImage *pixmap_image_new(char const *name, int width, int height,
                               int max_color_val, PixMapImageType type)
@@ -191,11 +193,11 @@ int pixmap_image_save(PixMapImage const *image)
     if(!image_file) return -1;
 
     if(image->_type == Text)
-        write_ascii_file(image, image_file);
+        write_ascii_file_rgb(image, image_file);
     else if(image->_type == Binary && image->_max_color_value <= 255)
-        write_8_bit_binary_file(image, image_file);
+        write_8_bit_binary_file_rgb(image, image_file);
     else if(image->_type == Binary && image->_max_color_value > 255)
-        write_16_bit_binary_file(image, image_file);
+        write_16_bit_binary_file_rgb(image, image_file);
 
     fclose(image_file);
 
@@ -365,7 +367,7 @@ static int read_16_bit_binary_pixel_values(PixMapImage *image, FILE *image_file)
     return 0;
 }
 
-static int write_ascii_file(PixMapImage *image, FILE *image_file)
+static int write_ascii_file_rgb(PixMapImage *image, FILE *image_file)
 {
     fprintf(image_file, "%s\n%d %d\n%d\n", "P3", image->_width, image->_height,
             image->_max_color_value);
@@ -391,7 +393,7 @@ static int write_ascii_file(PixMapImage *image, FILE *image_file)
     }
 }
 
-static int write_8_bit_binary_file(PixMapImage *image, FILE *image_file)
+static int write_8_bit_binary_file_rgb(PixMapImage *image, FILE *image_file)
 {
     uint8_t *temp_pixels =
         malloc(sizeof(uint8_t) * image->_width * image->_height * 3);
@@ -424,7 +426,7 @@ static int write_8_bit_binary_file(PixMapImage *image, FILE *image_file)
     free(temp_pixels);
 }
 
-static int write_16_bit_binary_file(PixMapImage *image, FILE *image_file)
+static int write_16_bit_binary_file_rgb(PixMapImage *image, FILE *image_file)
 {
     uint16_t *temp_pixels =
         malloc(sizeof(uint16_t) * image->_width * image->_height * 3);
@@ -455,4 +457,16 @@ static int write_16_bit_binary_file(PixMapImage *image, FILE *image_file)
            image_file);
 
     free(temp_pixels);
+}
+
+static int write_ascii_file_greyscale(PixMapImage *image, FILE *image_file)
+{
+    fprintf(image_file, "%s\n%d %d\n%d\n", "P2", image->_width, image->_height,
+	    image->_max_color_value);
+    int total_pixels = image->_width * image->_height;
+    for(int i = 0; i < total_pixels; i += 2)
+    {
+	fprintf(image_file, "%d %d\n", image->_pixels[i].red
+		image->_pixels[i + 1].red);
+    }
 }

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -12,26 +12,36 @@ struct _PixMapImage
 
 static int get_metadata_value(FILE *file);
 static int read_ascii_pixel_values_rgb(PixMapImage *image, FILE *image_file);
-static int read_8_bit_binary_pixel_values_rgb(PixMapImage *image, FILE *image_file);
-static int read_16_bit_binary_pixel_values_rgb(PixMapImage *image, FILE *image_file);
+static int read_8_bit_binary_pixel_values_rgb(PixMapImage *image,
+                                              FILE *image_file);
+static int read_16_bit_binary_pixel_values_rgb(PixMapImage *image,
+                                               FILE *image_file);
 
-static int read_ascii_pixel_values_greyscale(PixMapImage *image, FILE *image_file);
-static int read_8_bit_binary_pixel_values_greyscale(PixMapImage *image, FILE *image_file);
-static int read_16_bit_binary_pixel_values_greyscale(PixMapImage *image, FILE *image_file);
+static int read_ascii_pixel_values_greyscale(PixMapImage *image,
+                                             FILE *image_file);
+static int read_8_bit_binary_pixel_values_greyscale(PixMapImage *image,
+                                                    FILE *image_file);
+static int read_16_bit_binary_pixel_values_greyscale(PixMapImage *image,
+                                                     FILE *image_file);
 
 static int write_ascii_file_rgb(PixMapImage const *image, FILE *image_file);
-static int write_8_bit_binary_file_rgb(PixMapImage const *image, FILE *image_file);
-static int write_16_bit_binary_file_rgb(PixMapImage const *image, FILE *image_file);
+static int write_8_bit_binary_file_rgb(PixMapImage const *image,
+                                       FILE *image_file);
+static int write_16_bit_binary_file_rgb(PixMapImage const *image,
+                                        FILE *image_file);
 
-static int write_ascii_file_greyscale(PixMapImage const *image, FILE *image_file);
-static int write_8_bit_binary_file_greyscale(PixMapImage const *image, FILE *image_file);
-static int write_16_bit_binary_file_greyscale(PixMapImage const *image, FILE *image_file);
+static int write_ascii_file_greyscale(PixMapImage const *image,
+                                      FILE *image_file);
+static int write_8_bit_binary_file_greyscale(PixMapImage const *image,
+                                             FILE *image_file);
+static int write_16_bit_binary_file_greyscale(PixMapImage const *image,
+                                              FILE *image_file);
 
 PixMapImage *pixmap_image_new(char const *name, int width, int height,
                               int max_color_val, PixMapImageType type)
 {
     type = (type == Text | type == Binary) ? type : Text;
-    
+
     PixMapImage *new_image = malloc(sizeof(*new_image));
 
     if(!new_image) return 0;
@@ -102,33 +112,32 @@ PixMapImage *pixmap_image_open(char const *name)
 
     if(sig[1] == '2')
     {
-	if(read_ascii_pixel_values_greyscale(new_image, image_file) < 0)
-	    return 0;
-    }	   
+        if(read_ascii_pixel_values_greyscale(new_image, image_file) < 0)
+            return 0;
+    }
     else if(sig[1] == '3')
     {
-        if(read_ascii_pixel_values_rgb(new_image, image_file) < 0)
-	    return 0;
+        if(read_ascii_pixel_values_rgb(new_image, image_file) < 0) return 0;
     }
     else if(sig[1] == '4' && new_image->_max_color_value <= 255)
     {
-	if(read_8_bit_binary_pixel_values_greyscale(new_image, image_file) < 0)
-	    return 0;
+        if(read_8_bit_binary_pixel_values_greyscale(new_image, image_file) < 0)
+            return 0;
     }
     else if(sig[1] == '4' && new_image->_max_color_value > 255)
     {
-	if(read_16_bit_binary_pixel_values_greyscale(new_image, image_file) < 0)
-	    return 0;
+        if(read_16_bit_binary_pixel_values_greyscale(new_image, image_file) < 0)
+            return 0;
     }
     else if(sig[1] == '6' && new_image->_max_color_value <= 255)
     {
         if(read_8_bit_binary_pixel_values_rgb(new_image, image_file) < 0)
-	    return 0;
+            return 0;
     }
     else if(sig[1] == '6' && new_image->_max_color_value > 255)
     {
         if(read_16_bit_binary_pixel_values_rgb(new_image, image_file) < 0)
-	    return 0;
+            return 0;
     }
     else
     {
@@ -210,13 +219,11 @@ RGB pixmap_image_get_pixel(PixMapImage const *image, int x, int y)
 
 int pixmap_image_save_rgb(PixMapImage const *image)
 {
-    if(!image->_file_name)
-	return -1;
+    if(!image->_file_name) return -1;
 
     FILE *image_file = fopen(image->_file_name, "w");
 
-    if(!image_file)
-	return -1;
+    if(!image_file) return -1;
 
     if(image->_type == Text)
         write_ascii_file_rgb(image, image_file);
@@ -232,18 +239,16 @@ int pixmap_image_save_rgb(PixMapImage const *image)
 
 int pixmap_image_save_greyscale(PixMapImage const *image)
 {
-    if(!image->_file_name)
-	return -1;
+    if(!image->_file_name) return -1;
 
     FILE *image_file = fopen(image->_file_name, "w");
-    if(!image_file)
-	return -1;
+    if(!image_file) return -1;
     if(image->_type == Text)
-	write_ascii_file_greyscale(image, image_file);
+        write_ascii_file_greyscale(image, image_file);
     else if(image->_type == Binary && image->_max_color_value <= 255)
-	write_8_bit_binary_file_greyscale(image, image_file);
+        write_8_bit_binary_file_greyscale(image, image_file);
     else if(image->_type == Binary && image->_max_color_value > 255)
-	write_16_bit_binary_file_greyscale(image, image_file);
+        write_16_bit_binary_file_greyscale(image, image_file);
 
     fclose(image_file);
     return 0;
@@ -362,7 +367,8 @@ static int read_ascii_pixel_values_rgb(PixMapImage *image, FILE *image_file)
     return 0;
 }
 
-static int read_8_bit_binary_pixel_values_rgb(PixMapImage *image, FILE *image_file)
+static int read_8_bit_binary_pixel_values_rgb(PixMapImage *image,
+                                              FILE *image_file)
 {
     int total_pixels = image->_width * image->_height;
     uint8_t value_in[3];
@@ -387,7 +393,8 @@ static int read_8_bit_binary_pixel_values_rgb(PixMapImage *image, FILE *image_fi
     return 0;
 }
 
-static int read_16_bit_binary_pixel_values_rgb(PixMapImage *image, FILE *image_file)
+static int read_16_bit_binary_pixel_values_rgb(PixMapImage *image,
+                                               FILE *image_file)
 {
     int total_pixels = image->_width * image->_height;
     uint16_t value_in[3];
@@ -412,7 +419,8 @@ static int read_16_bit_binary_pixel_values_rgb(PixMapImage *image, FILE *image_f
     return 0;
 }
 
-static int read_ascii_pixel_values_greyscale(PixMapImage *image, FILE *image_file)
+static int read_ascii_pixel_values_greyscale(PixMapImage *image,
+                                             FILE *image_file)
 {
     int c;
     unsigned int value_in = 0;
@@ -431,10 +439,9 @@ static int read_ascii_pixel_values_greyscale(PixMapImage *image, FILE *image_fil
                 value_in *= 10;
                 value_in += (c - '0');
             }
-	    image->_pixels[file_pos] = (RGB) {.red = value_in,
-				       .green = value_in,
-				       .blue = value_in};
-	    file_pos++;
+            image->_pixels[file_pos] =
+                (RGB){.red = value_in, .green = value_in, .blue = value_in};
+            file_pos++;
         }
     }
 
@@ -450,48 +457,48 @@ static int read_ascii_pixel_values_greyscale(PixMapImage *image, FILE *image_fil
     return 0;
 }
 
-static int read_8_bit_binary_pixel_values_greyscale(PixMapImage *image, FILE *image_file)
+static int read_8_bit_binary_pixel_values_greyscale(PixMapImage *image,
+                                                    FILE *image_file)
 {
     uint8_t value_in = 0;
     int total_pixels = image->_width * image->_height;
-    
+
     for(int i = 0; i < total_pixels; i++)
     {
-	fread(&value_in, sizeof(uint8_t), 1, image_file);
-	if(ferror(image_file))
-	{
-	    fclose(image_file);
-	    pixmap_image_close(image);
-	    return -1;
-	}
-	image->_pixels[i] = (RGB) {.red = value_in,
-				   .green = value_in,
-				   .blue = value_in};
+        fread(&value_in, sizeof(uint8_t), 1, image_file);
+        if(ferror(image_file))
+        {
+            fclose(image_file);
+            pixmap_image_close(image);
+            return -1;
+        }
+        image->_pixels[i] =
+            (RGB){.red = value_in, .green = value_in, .blue = value_in};
     }
     return 0;
 }
 
-static int read_16_bit_binary_pixel_values_greyscale(PixMapImage *image, FILE *image_file)
+static int read_16_bit_binary_pixel_values_greyscale(PixMapImage *image,
+                                                     FILE *image_file)
 {
     uint16_t value_in = 0;
     int total_pixels = image->_width * image->_height;
-    
+
     for(int i = 0; i < total_pixels; i++)
     {
-	fread(&value_in, sizeof(uint16_t), 1, image_file);
-	if(ferror(image_file))
-	{
-	    fclose(image_file);
-	    pixmap_image_close(image);
-	    return -1;
-	}
-	image->_pixels[i] = (RGB) {.red = value_in,
-				   .green = value_in,
-				   .blue = value_in};
+        fread(&value_in, sizeof(uint16_t), 1, image_file);
+        if(ferror(image_file))
+        {
+            fclose(image_file);
+            pixmap_image_close(image);
+            return -1;
+        }
+        image->_pixels[i] =
+            (RGB){.red = value_in, .green = value_in, .blue = value_in};
     }
     return 0;
 }
-	
+
 
 static int write_ascii_file_rgb(PixMapImage const *image, FILE *image_file)
 {
@@ -520,7 +527,8 @@ static int write_ascii_file_rgb(PixMapImage const *image, FILE *image_file)
     return 0;
 }
 
-static int write_8_bit_binary_file_rgb(PixMapImage  const *image, FILE *image_file)
+static int write_8_bit_binary_file_rgb(PixMapImage const *image,
+                                       FILE *image_file)
 {
     uint8_t *temp_pixels =
         malloc(sizeof(uint8_t) * image->_width * image->_height * 3);
@@ -554,7 +562,8 @@ static int write_8_bit_binary_file_rgb(PixMapImage  const *image, FILE *image_fi
     return 0;
 }
 
-static int write_16_bit_binary_file_rgb(PixMapImage const *image, FILE *image_file)
+static int write_16_bit_binary_file_rgb(PixMapImage const *image,
+                                        FILE *image_file)
 {
     uint16_t *temp_pixels =
         malloc(sizeof(uint16_t) * image->_width * image->_height * 3);
@@ -588,53 +597,56 @@ static int write_16_bit_binary_file_rgb(PixMapImage const *image, FILE *image_fi
     return 0;
 }
 
-static int write_ascii_file_greyscale(PixMapImage const *image, FILE *image_file)
+static int write_ascii_file_greyscale(PixMapImage const *image,
+                                      FILE *image_file)
 {
     fprintf(image_file, "%s\n%d %d\n%d\n", "P2", image->_width, image->_height,
-	    image->_max_color_value);
+            image->_max_color_value);
     int total_pixels = image->_width * image->_height;
     for(int i = 0; i < total_pixels; i += 2)
     {
-	fprintf(image_file, "%d %d\n", image->_pixels[i].red,
-		image->_pixels[i + 1].red);
+        fprintf(image_file, "%d %d\n", image->_pixels[i].red,
+                image->_pixels[i + 1].red);
     }
     return 0;
 }
 
-static int write_8_bit_binary_file_greyscale(PixMapImage const *image, FILE *image_file)
+static int write_8_bit_binary_file_greyscale(PixMapImage const *image,
+                                             FILE *image_file)
 {
     int total_pixels = image->_width * image->_height;
     uint8_t *temp_pixels = malloc(sizeof(uint8_t) * total_pixels);
     if(!temp_pixels)
     {
-	fclose(image_file);
-	return -1;
+        fclose(image_file);
+        return -1;
     }
     for(int i = 0; i < total_pixels; i++)
-	temp_pixels[i] = image->_pixels[i].red;
-    
+        temp_pixels[i] = image->_pixels[i].red;
+
     fprintf(image_file, "%s\n%d %d\n%d\n", "P4", image->_width, image->_height,
-	    image->_max_color_value);
+            image->_max_color_value);
     fwrite(temp_pixels, sizeof(uint8_t), total_pixels, image_file);
 
     free(temp_pixels);
     return 0;
 }
 
-static int write_16_bit_binary_file_greyscale(PixMapImage const *image, FILE *image_file)
+static int write_16_bit_binary_file_greyscale(PixMapImage const *image,
+                                              FILE *image_file)
 {
     int total_pixels = image->_width * image->_height;
     uint16_t *temp_pixels = malloc(sizeof(uint16_t) * total_pixels);
     if(!temp_pixels)
     {
-	fclose(image_file);
-	return -1;
+        fclose(image_file);
+        return -1;
     }
     for(int i = 0; i < total_pixels; i++)
-	temp_pixels[i] = htons(image->_pixels[i].red);
-    
+        temp_pixels[i] = htons(image->_pixels[i].red);
+
     fprintf(image_file, "%s\n%d %d\n%d\n", "P4", image->_width, image->_height,
-	    image->_max_color_value);
+            image->_max_color_value);
     fwrite(temp_pixels, sizeof(uint16_t), total_pixels, image_file);
 
     free(temp_pixels);

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -624,7 +624,7 @@ static int write_8_bit_binary_file_greyscale(PixMapImage const *image, FILE *ima
 static int write_16_bit_binary_file_greyscale(PixMapImage const *image, FILE *image_file)
 {
     int total_pixels = image->_width * image->_height;
-    uint16_t *temp_pixels = malloc(sizeof(uint8_t) * total_pixels);
+    uint16_t *temp_pixels = malloc(sizeof(uint16_t) * total_pixels);
     if(!temp_pixels)
     {
 	fclose(image_file);

--- a/src/pixmap.c
+++ b/src/pixmap.c
@@ -208,13 +208,15 @@ RGB pixmap_image_get_pixel(PixMapImage const *image, int x, int y)
     return image->_pixels[x + (y * image->_width)];
 }
 
-int pixmap_image_save(PixMapImage const *image)
+int pixmap_image_save_rgb(PixMapImage const *image)
 {
-    if(!image->_file_name) return -1;
+    if(!image->_file_name)
+	return -1;
 
     FILE *image_file = fopen(image->_file_name, "w");
 
-    if(!image_file) return -1;
+    if(!image_file)
+	return -1;
 
     if(image->_type == Text)
         write_ascii_file_rgb(image, image_file);
@@ -225,6 +227,25 @@ int pixmap_image_save(PixMapImage const *image)
 
     fclose(image_file);
 
+    return 0;
+}
+
+int pixmap_image_save_greyscale(PixMapImage const *image)
+{
+    if(!image->_file_name)
+	return -1;
+
+    FILE *image_file = fopen(image->_file_name, "w");
+    if(!image_file)
+	return -1;
+    if(image->_type == Text)
+	write_ascii_file_greyscale(image, image_file);
+    else if(image->_type == Binary && image->_max_color_value <= 255)
+	write_8_bit_binary_file_greyscale(image, image_file);
+    else if(image->_type == Binary && image->_max_color_value > 255)
+	write_16_bit_binary_file_greyscale(image, image_file);
+
+    fclose(image_file);
     return 0;
 }
 

--- a/src/pixmap.h
+++ b/src/pixmap.h
@@ -1,11 +1,11 @@
 #pragma once
 
+#include <arpa/inet.h> /* htons, ntohs (Linux only) */
+#include <ctype.h>
+#include <stdint.h> /* uint8_t */
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include <ctype.h>
-#include <stdint.h>		/* uint8_t */
-#include <arpa/inet.h>		/* htons, ntohs (Linux only) */
 
 
 typedef struct _PixMapImage PixMapImage;
@@ -23,25 +23,24 @@ typedef enum
     Binary = 2
 } PixMapImageType;
 
-PixMapImage *pixmap_image_new                (char const *name, int width, int height, int max_color_val, PixMapImageType type);
-PixMapImage *pixmap_image_open               (char const *name);
-PixMapImage *pixmap_image_copy               (PixMapImage  const *image, char const *new_name, PixMapImageType type);
-RGB         *pixmap_image_get_pixel_array    (PixMapImage const *image);
-void         pixmap_image_set_pixel          (PixMapImage *image,
-                                              int x, int y,
-                                              int red, int green, int blue,
-                                              int *error);
-void         pixmap_image_set_pixel_by_rgb   (PixMapImage *image,
-                                              int x, int y,
-                                              RGB *rgb, int *error);
-RGB          pixmap_image_get_pixel          (PixMapImage const *image, int x, int y);
-int          pixmap_image_save_rgb           (PixMapImage const *image);
-int          pixmap_image_save_greyscale     (PixMapImage const *image);
-int          pixmap_image_get_width          (PixMapImage const *image);
-int          pixmap_image_get_height         (PixMapImage const *image);
-int          pixmap_image_get_max_color_value(PixMapImage const *image);
-PixMapImageType pixmap_image_get_type        (PixMapImage const *image);
-void         pixmap_image_foreach_pixel      (PixMapImage *image,
-					      void (*func)(RGB pixel, void *func_arg),
-					      void * arg);
-void         pixmap_image_close              (PixMapImage *image);
+PixMapImage *pixmap_image_new(char const *name, int width, int height,
+                              int max_color_val, PixMapImageType type);
+PixMapImage *pixmap_image_open(char const *name);
+PixMapImage *pixmap_image_copy(PixMapImage const *image, char const *new_name,
+                               PixMapImageType type);
+RGB *pixmap_image_get_pixel_array(PixMapImage const *image);
+void pixmap_image_set_pixel(PixMapImage *image, int x, int y, int red,
+                            int green, int blue, int *error);
+void pixmap_image_set_pixel_by_rgb(PixMapImage *image, int x, int y, RGB *rgb,
+                                   int *error);
+RGB pixmap_image_get_pixel(PixMapImage const *image, int x, int y);
+int pixmap_image_save_rgb(PixMapImage const *image);
+int pixmap_image_save_greyscale(PixMapImage const *image);
+int pixmap_image_get_width(PixMapImage const *image);
+int pixmap_image_get_height(PixMapImage const *image);
+int pixmap_image_get_max_color_value(PixMapImage const *image);
+PixMapImageType pixmap_image_get_type(PixMapImage const *image);
+void pixmap_image_foreach_pixel(PixMapImage *image,
+                                void (*func)(RGB pixel, void *func_arg),
+                                void *arg);
+void pixmap_image_close(PixMapImage *image);

--- a/src/pixmap.h
+++ b/src/pixmap.h
@@ -35,7 +35,8 @@ void         pixmap_image_set_pixel_by_rgb   (PixMapImage *image,
                                               int x, int y,
                                               RGB *rgb, int *error);
 RGB          pixmap_image_get_pixel          (PixMapImage const *image, int x, int y);
-int          pixmap_image_save               (PixMapImage const *image);
+int          pixmap_image_save_rgb           (PixMapImage const *image);
+int          pixmap_image_save_greyscale     (PixMapImage const *image);
 int          pixmap_image_get_width          (PixMapImage const *image);
 int          pixmap_image_get_height         (PixMapImage const *image);
 int          pixmap_image_get_max_color_value(PixMapImage const *image);

--- a/test/main.c
+++ b/test/main.c
@@ -22,9 +22,9 @@ int test1()
     PixMapImage *image_copy = pixmap_image_copy(image, "test_copy.ppm", Text);
     if(!image_copy) return -1;
 
-    if(pixmap_image_save(image) != 0) return -1;
+    if(pixmap_image_save_rgb(image) != 0) return -1;
 
-    if(pixmap_image_save(image_copy) != 0) return -1;
+    if(pixmap_image_save_rgb(image_copy) != 0) return -1;
 
     pixmap_image_close(image);
     pixmap_image_close(image_copy);
@@ -43,7 +43,7 @@ int test2()
 
     if(!image_out) return -1;
 
-    int status = pixmap_image_save(image_out);
+    int status = pixmap_image_save_rgb(image_out);
 
     if(status != 0) return -1;
 
@@ -67,7 +67,7 @@ int test3()
         }
     }
 
-    pixmap_image_save(image);
+    pixmap_image_save_rgb(image);
 
     pixmap_image_close(image);
     return 0;
@@ -85,7 +85,7 @@ int test4(void)
     if(!image_out) return -1;
 
 
-    if(pixmap_image_save(image_out) != 0) return -1;
+    if(pixmap_image_save_rgb(image_out) != 0) return -1;
 
     pixmap_image_close(image);
     pixmap_image_close(image_out);
@@ -129,7 +129,7 @@ int test6()
 
     pixmap_filter_brightness(image, -9, error);
     if(error) return -1;
-    pixmap_image_save(image);
+    pixmap_image_save_rgb(image);
 }
 
 int test7()
@@ -142,13 +142,25 @@ int test7()
     pixmap_filter_desaturate_average(out, &error);
     if(error)
 	return -1;
-    if(pixmap_image_save(out) != 0)
+    if(pixmap_image_save_rgb(out) != 0)
 	return -1;
     pixmap_image_close(in);
     pixmap_image_close(out);
     return 0;
 }
-    
+
+int test8()
+{
+    PixMapImage *in = pixmap_image_open("test7_image.ppm");
+    PixMapImage *out = pixmap_image_copy(in, "test8_image.pgm", Binary);
+    if(!out)
+	return -1;
+    if(pixmap_image_save_greyscale(out) != 0)
+	return -1;
+    pixmap_image_close(in);
+    pixmap_image_close(out);
+    return 0;
+}
 
 int main()
 {
@@ -166,6 +178,9 @@ int main()
 
     if(test7() != 0)
 	return 7;
+
+    if(test8() != 0)
+	return 8;
 
     return 0;
 }

--- a/test/main.c
+++ b/test/main.c
@@ -136,14 +136,11 @@ int test7()
 {
     PixMapImage *in = pixmap_image_open("test6_image.ppm");
     PixMapImage *out = pixmap_image_copy(in, "test7_image.ppm", Text);
-    if(!out)
-	return -1;
+    if(!out) return -1;
     int error = 0;
     pixmap_filter_desaturate_average(out, &error);
-    if(error)
-	return -1;
-    if(pixmap_image_save_rgb(out) != 0)
-	return -1;
+    if(error) return -1;
+    if(pixmap_image_save_rgb(out) != 0) return -1;
     pixmap_image_close(in);
     pixmap_image_close(out);
     return 0;
@@ -153,10 +150,8 @@ int test8()
 {
     PixMapImage *in = pixmap_image_open("test7_image.ppm");
     PixMapImage *out = pixmap_image_copy(in, "test8_image.pgm", Binary);
-    if(!out)
-	return -1;
-    if(pixmap_image_save_greyscale(out) != 0)
-	return -1;
+    if(!out) return -1;
+    if(pixmap_image_save_greyscale(out) != 0) return -1;
     pixmap_image_close(in);
     pixmap_image_close(out);
     return 0;
@@ -176,11 +171,9 @@ int main()
 
     if(test6() != 0) return 6;
 
-    if(test7() != 0)
-	return 7;
+    if(test7() != 0) return 7;
 
-    if(test8() != 0)
-	return 8;
+    if(test8() != 0) return 8;
 
     return 0;
 }


### PR DESCRIPTION
Greyscale files will be written using the pixel red values; if a non-greyscale image is saved with the greyscale functions, information will be lost.